### PR TITLE
Update cd-workflow.yml

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -59,7 +59,7 @@ jobs:
         name: webpack artifacts
         path: public
     - name: Build container image
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: ${{github.actor}}
         password: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
I was going through this lab and I've got this error:
Docker Build, Tag, Push
Input 'repository' has been deprecated with message: v2 is now available through docker/build-push-action@v2

I believe this file has to be updated in line 62 with docker/build-push-action@v2